### PR TITLE
Add config-manager service.

### DIFF
--- a/lib/classes/Unit.ls
+++ b/lib/classes/Unit.ls
@@ -1,5 +1,4 @@
 require! \../services/login-manager.ls
-login-manager.read!
 
 module.exports = class DockerContainerServiceUnit
   ({@name, @config, @layout, @index})->

--- a/lib/index.ls
+++ b/lib/index.ls
@@ -8,7 +8,6 @@ module.exports =
   run: ->
     command-manager.read!
     command-manager.check!
-    login-manager.read!
     login-manager.check!
     options-manager.read!
     options-manager.check!

--- a/lib/services/config-manager.ls
+++ b/lib/services/config-manager.ls
@@ -1,0 +1,20 @@
+require! <[yaml-js fs]>
+{load, dump} = yaml-js
+config_file = "#{process.env.HOME or process.env.USERPROFILE}/.glad-fleeter"
+read-yml = fs.read-file-sync >> load
+write-yml = dump >> fs.write-file-sync config_file, _
+
+module.exports = new class ConfigManager
+  -> @read!
+  read: ->
+    try
+      @config-file = read-yml config_file
+    catch e
+      @auth = {}
+  auth:~
+    -> @config-file?.(\docker-auth) or {}
+    (auth)->
+      unless @config-file |> is-type \Object then @config-file = {}
+      @config-file.(\docker-auth) = auth
+  save: -> write-yml @config-file
+

--- a/lib/services/login-manager.ls
+++ b/lib/services/login-manager.ls
@@ -1,8 +1,5 @@
-require! <[https yaml-js fs]>
-{load, dump} = yaml-js
-config_file = "#{process.env.HOME or process.env.USERPROFILE}/.glad-fleeter"
-read-yml = fs.read-file-sync >> load
-write-yml = dump >> fs.write-file-sync config_file, _
+require! <[https]>
+require! \./config-manager
 
 module.exports = new class LoginManager
   configs:
@@ -20,15 +17,8 @@ module.exports = new class LoginManager
   need_to_be_logged_in:~ -> @config.required
   is_logged_in:~ -> not Obj.empty @auth
   auth:~
-    -> @config-file?.(\docker-auth) or {}
-    (auth)->
-      unless @config-file |> is-type \Object then @config-file = {}
-      @config-file.(\docker-auth) = auth
-  read: ->
-    try
-      @config-file = read-yml config_file
-    catch e
-      @auth = {}
+    -> config-manager.auth
+    (auth)-> config-manager.auth = auth
   check: ->
     unless @need_to_be_logged_in then return
     unless @is_logged_in
@@ -47,7 +37,7 @@ module.exports = new class LoginManager
       .on \error, ->
         console.error it
         cb it, false
-  save: -> write-yml @config-file
+  save: -> config-manager.save!
   save_of: ({user, password, email})->
     @auth = {user, password, email}
     @save!


### PR DESCRIPTION
login-manager.lsが設定ファイルの書き換えも行っていたので、
lib/services/config-manager.lsファイルに分離しました。

目的としては2点
- 今後の別プロジェクトに移植しやすくする
- (今後の拡張性を考慮して)login以外のコマンドでも設定ファイルに保存出来るようにしておく
